### PR TITLE
Mobile Navbar menu fix

### DIFF
--- a/src/components/elements/Navbar.tsx
+++ b/src/components/elements/Navbar.tsx
@@ -186,5 +186,5 @@ const Drawer = styled(NavbarBaseStyle)<{ theme: string; open: boolean }>`
   @media screen and (max-width: ${breakpoints.md}) {
     display: flex;
   }
-  z-index: 0;
+  z-index: 15;
 `;


### PR DESCRIPTION
Previously the menu of the navbar showed behind the content on the Rólunk page (on mobile)